### PR TITLE
[OPS-11981] Python 3.13, dependencies update, tests

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,58 @@
+name: Build image and test API
+
+on: [pull_request]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image
+        run: |
+          docker build \
+            --build-arg VCS_REF=${{ github.sha }} \
+            --build-arg VCS_URL=${{ github.server_url }}/${{ github.repository }} \
+            --build-arg BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ") \
+            --build-arg GITHUB_ACTOR=${{ github.actor }} \
+            --build-arg GITHUB_REPOSITORY=${{ github.repository }} \
+            --build-arg GITHUB_SHA=${{ github.sha }} \
+            --build-arg GITHUB_REF=${{ github.ref }} \
+            . --file docker/Dockerfile --tag ocha-ai-helper:test
+
+      - name: Run container
+        run: |
+          docker run -d -p 8000:8000 --name api ocha-ai-helper:test
+
+      - name: Wait for API
+        run: |
+          for i in $(seq 1 60); do
+            if curl -sf http://localhost:8000/status > /dev/null; then
+              echo "API ready"
+              exit 0
+            fi
+            echo "Waiting for API... ($i/60)"
+            sleep 5
+          done
+          echo "API did not become ready"
+          exit 1
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+          cache: 'pip'
+
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r html/requirements-test.txt
+
+      - name: Run tests against container API
+        env:
+          API_BASE_URL: http://localhost:8000
+        run: pytest -v

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ buildlog.txt
 
 # Python cache.
 /html/__pycache__
+/tests/__pycache__

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # Build the code.
-FROM python:3.12 AS builder
+FROM python:3.13 AS builder
 
 ENV S6VERSION=2.2.0.3
 
@@ -18,7 +18,7 @@ RUN pip install --root-user-action=ignore --upgrade pip setuptools wheel && \
     /opt/venv/bin/pip install -r /srv/www/html/requirements.txt
 
 # Generate the image.
-FROM python:3.12-slim
+FROM python:3.13-slim
 
 ARG VCS_REF
 ARG VCS_URL
@@ -51,7 +51,7 @@ ENV PATH=/opt/venv/bin:$PATH
 RUN \
     apt-get clean && apt-get update && apt-get -y install netcat-openbsd procps && \
     tar xzf /tmp/s6-overlay.tar.gz -C / && \
-    rm -f tar xzf /tmp/s6-overlay.tar.gz && \
+    rm -f /tmp/s6-overlay.tar.gz && \
     # Add some users.
     addgroup --system --gid 4000 appuser && \
     adduser --system --uid 4000 --gid 4000 --shell /sbin/nologin --comment 'Docker App User' --home /home/appuser --no-create-home appuser && \

--- a/html/__init__.py
+++ b/html/__init__.py
@@ -1,0 +1,1 @@
+# html app package

--- a/html/app.py
+++ b/html/app.py
@@ -230,9 +230,9 @@ def text_tokenize_text(request: TextTokenizeTextRequest) -> TextTokenizeSentence
     # Process the text.
     document = nlp_models[request.language](request.text)
 
-    # Retrieve the tokens and ensure uniqueness.
+    # Retrieve the tokens and ensure uniqueness (order preserved).
     tokens = [token.text.strip().lower() for token in document if not token.is_space]
-    tokens = list(set(tokens))
+    tokens = list(dict.fromkeys(tokens))
 
     return TextTokenizeSentencesResponse(tokens=tokens, took=took(start_time))
 

--- a/html/requirements-test.txt
+++ b/html/requirements-test.txt
@@ -1,0 +1,4 @@
+# Test dependencies for html app.
+-r requirements.txt
+httpx>=0.27
+pytest>=8.0

--- a/html/requirements.txt
+++ b/html/requirements.txt
@@ -1,7 +1,7 @@
 fastapi~=0.128
 flashrank~=0.2
-pydantic~=2.8
-pylint~=3.3
-rapidfuzz~=3.13
-spacy==3.7.5
+pydantic>=2.12,<3
+pylint>=4.0
+rapidfuzz~=3.14
+spacy>=3.8
 uvicorn~=0.39

--- a/local/exec.sh
+++ b/local/exec.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -e -u
+
+docker compose -f local/docker-compose.yml exec "$@"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+pythonpath = .

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# Tests for html app.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,83 @@
+"""
+Pytest configuration and fixtures. Mocks spacy and flashrank so tests run
+without loading real language models. When API_BASE_URL is set, tests run
+against that live API instead (e.g. a running container).
+"""
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# When API_BASE_URL is set we talk to a live server and skip loading the app.
+if os.environ.get("API_BASE_URL"):
+    _app = None
+else:
+    import httpx
+    from fastapi.testclient import TestClient
+
+    def _make_mock_doc(sents_texts=None, token_texts=None):
+        """Build a mock spacy-like document with .sents and token iteration."""
+        doc = MagicMock()
+        if sents_texts is None:
+            sents_texts = ["First sentence.", "Second sentence.", "Third sentence."]
+        doc.sents = [MagicMock(text=s) for s in sents_texts]
+        if token_texts is None:
+            token_texts = ["hello", "world", ",", "this", "is", "a", "wide", "test"]
+        tokens = []
+        for t in token_texts:
+            tok = MagicMock()
+            tok.text = t
+            tok.is_space = False
+            tok.is_stop = False
+            tok.is_punct = False
+            tokens.append(tok)
+        doc.__iter__ = lambda self: iter(tokens)
+        return doc
+
+    def _make_mock_nlp():
+        return MagicMock(side_effect=lambda text: _make_mock_doc())
+
+    def _make_mock_ranker():
+        ranker = MagicMock()
+        ranker.rerank = MagicMock(
+            return_value=[
+                {"text": "most relevant", "score": 0.95},
+                {"text": "second", "score": 0.8},
+            ]
+        )
+        return ranker
+
+    _mock_spacy = MagicMock()
+    _mock_spacy.load = MagicMock(return_value=_make_mock_nlp())
+    _mock_flashrank = MagicMock()
+    _mock_flashrank.Ranker = MagicMock(return_value=_make_mock_ranker())
+    _mock_flashrank.RerankRequest = MagicMock()
+
+    with patch.dict(
+        sys.modules,
+        {"spacy": _mock_spacy, "flashrank": _mock_flashrank},
+    ):
+        from html.app import app as _app  # noqa: E402
+
+
+@pytest.fixture(scope="session")
+def app():
+    """FastAPI app (loaded with mocked spacy and flashrank), or None when using live API."""
+    return _app
+
+
+@pytest.fixture
+def client(app):
+    """HTTP client: live httpx client when API_BASE_URL is set, else TestClient(app)."""
+    if os.environ.get("API_BASE_URL"):
+        import httpx
+
+        base_url = os.environ["API_BASE_URL"].rstrip("/")
+        client_instance = httpx.Client(base_url=base_url, timeout=30.0)
+        yield client_instance
+        client_instance.close()
+    else:
+        from fastapi.testclient import TestClient
+
+        yield TestClient(app)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,293 @@
+"""
+Tests for the text manipulation API (app.py).
+"""
+
+
+# -----------------------------------------------------------------------------
+# Health
+# -----------------------------------------------------------------------------
+
+
+def test_health_status_returns_ok(client):
+    """GET /status returns 200 and status ok."""
+    response = client.get("/status")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "ok"
+
+
+# -----------------------------------------------------------------------------
+# Text split sentences
+# -----------------------------------------------------------------------------
+
+
+def test_text_split_sentences_success(client):
+    """POST /text/split/sentences returns sentences and took."""
+    payload = {"language": "en", "text": "First sentence. Second sentence. Third sentence."}
+    response = client.post("/text/split/sentences", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert "sentences" in data
+    assert "took" in data
+    assert isinstance(data["sentences"], list)
+    assert len(data["sentences"]) == 3
+    assert data["sentences"] == ["First sentence.", "Second sentence.", "Third sentence."]
+
+
+def test_text_split_sentences_unsupported_language(client):
+    """POST /text/split/sentences with unsupported language returns 400."""
+    payload = {"language": "xx", "text": "Some text."}
+    response = client.post("/text/split/sentences", json=payload)
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Unsupported language"
+
+
+def test_text_split_sentences_missing_text(client):
+    """POST /text/split/sentences with empty text returns 400."""
+    payload = {"language": "en", "text": ""}
+    response = client.post("/text/split/sentences", json=payload)
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Missing text"
+
+
+# -----------------------------------------------------------------------------
+# Text tokenize
+# -----------------------------------------------------------------------------
+
+
+def test_text_tokenize_text_success(client):
+    """POST /text/tokenize/text returns tokens and took."""
+    payload = {"language": "en", "text": "hello world, this is a world wide test"}
+    response = client.post("/text/tokenize/text", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert "tokens" in data
+    assert "took" in data
+    assert isinstance(data["tokens"], list)
+    assert len(data["tokens"]) == 8
+    assert data["tokens"] == ["hello", "world", ",", "this", "is", "a", "wide", "test"]
+
+
+def test_text_tokenize_text_unsupported_language(client):
+    """POST /text/tokenize/text with unsupported language returns 400."""
+    payload = {"language": "xx", "text": "hello"}
+    response = client.post("/text/tokenize/text", json=payload)
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Unsupported language"
+
+
+def test_text_tokenize_text_missing_text(client):
+    """POST /text/tokenize/text with empty text returns 400."""
+    payload = {"language": "en", "text": ""}
+    response = client.post("/text/tokenize/text", json=payload)
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Missing text"
+
+
+# -----------------------------------------------------------------------------
+# Text correlate keywords
+# -----------------------------------------------------------------------------
+
+
+def test_text_correlate_keywords_success(client):
+    """POST /text/correlate/keywords returns keywords and took."""
+    payload = {
+        "language": "en",
+        "text": "Some document about health and nutrition.",
+        "keywords": ["health", "food"],
+        "limit": 10,
+    }
+    response = client.post("/text/correlate/keywords", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert "keywords" in data
+    assert "took" in data
+    assert isinstance(data["keywords"], list)
+    # Result = doc tokens + ranked keywords; with mocks we get mock tokens + ranker hits
+    assert len(data["keywords"]) > 0
+    # With live API, "health" and "food" are relevant; with mocks, ranker returns fixed strings
+    assert any(
+        k in data["keywords"] for k in ("health", "food", "most relevant")
+    ), "keywords should contain requested or ranked terms"
+
+
+def test_text_correlate_keywords_unsupported_language(client):
+    """POST /text/correlate/keywords with unsupported language returns 400."""
+    payload = {
+        "language": "xx",
+        "text": "Some text.",
+        "keywords": ["foo"],
+    }
+    response = client.post("/text/correlate/keywords", json=payload)
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Unsupported language"
+
+
+def test_text_correlate_keywords_missing_text(client):
+    """POST /text/correlate/keywords with empty text returns 400."""
+    payload = {"language": "en", "text": "", "keywords": ["foo"]}
+    response = client.post("/text/correlate/keywords", json=payload)
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Missing text"
+
+
+def test_text_correlate_keywords_missing_keywords(client):
+    """POST /text/correlate/keywords with empty keywords returns 400."""
+    payload = {"language": "en", "text": "Some text.", "keywords": []}
+    response = client.post("/text/correlate/keywords", json=payload)
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Missing keywords"
+
+
+# -----------------------------------------------------------------------------
+# Text correlate texts
+# -----------------------------------------------------------------------------
+
+
+def test_text_correlate_texts_success(client):
+    """POST /text/correlate/texts returns ranked texts and took."""
+    payload = {
+        "language": "en",
+        "text": "Query about climate.",
+        "texts": ["Doc about food.", "Doc about climate change.", "Doc about sports."],
+        "limit": 5,
+    }
+    response = client.post("/text/correlate/texts", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert "texts" in data
+    assert "took" in data
+    assert isinstance(data["texts"], dict)
+    assert data["texts"]
+    scores = data["texts"]
+    # With live API: climate doc ranks highest for "Query about climate."
+    # With mocks: ranker returns fixed keys "most relevant", "second"
+    if "Doc about climate change." in scores:
+        assert scores["Doc about climate change."] == max(scores.values())
+    else:
+        assert all(isinstance(v, (int, float)) for v in scores.values())
+        assert max(scores.values()) > 0
+
+
+def test_text_correlate_texts_unsupported_language(client):
+    """POST /text/correlate/texts with unsupported language returns 400."""
+    payload = {
+        "language": "xx",
+        "text": "Query.",
+        "texts": ["Doc one."],
+    }
+    response = client.post("/text/correlate/texts", json=payload)
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Unsupported language"
+
+
+def test_text_correlate_texts_missing_text(client):
+    """POST /text/correlate/texts with empty text returns 400."""
+    payload = {"language": "en", "text": "", "texts": ["Doc."]}
+    response = client.post("/text/correlate/texts", json=payload)
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Missing text"
+
+
+def test_text_correlate_texts_missing_texts(client):
+    """POST /text/correlate/texts with empty texts returns 400."""
+    payload = {"language": "en", "text": "Query.", "texts": []}
+    response = client.post("/text/correlate/texts", json=payload)
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Missing texts"
+
+
+# -----------------------------------------------------------------------------
+# Text match lines
+# -----------------------------------------------------------------------------
+
+
+def test_text_match_lines_success(client):
+    """POST /text/match/lines returns matching lines and took."""
+    payload = {
+        "language": "en",
+        "text": "human rights and humanitarian action",
+        "lines": [
+            "Human rights are important.",
+            "Humanitarian action in crisis.",
+            "Sports and games.",
+        ],
+        "threshold": 70,
+    }
+    response = client.post("/text/match/lines", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert "lines" in data
+    assert "took" in data
+    assert isinstance(data["lines"], list)
+    # Lines about human rights / humanitarian action match at threshold 70; sports does not
+    assert "Human rights are important." in data["lines"]
+    assert "Humanitarian action in crisis." in data["lines"]
+    assert "Sports and games." not in data["lines"]
+    assert len(data["lines"]) == 2
+
+
+def test_text_match_lines_exact_match(client):
+    """POST /text/match/lines with exact line returns that line only."""
+    payload = {
+        "language": "en",
+        "text": "exact phrase",
+        "lines": ["exact phrase", "other line"],
+        "threshold": 100,
+    }
+    response = client.post("/text/match/lines", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["lines"] == ["exact phrase"]
+    assert "other line" not in data["lines"]
+
+
+def test_text_match_lines_high_threshold_filters(client):
+    """POST /text/match/lines with high threshold returns fewer matches."""
+    payload = {
+        "language": "en",
+        "text": "human rights",
+        "lines": ["Human rights matter.", "Something else."],
+        "threshold": 95,
+    }
+    response = client.post("/text/match/lines", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert isinstance(data["lines"], list)
+    # Unrelated line must not match at high threshold
+    assert "Something else." not in data["lines"]
+    # At 95 we may get 0 or 1 match; if any, it should be the relevant line
+    if data["lines"]:
+        assert data["lines"] == ["Human rights matter."]
+
+
+def test_text_match_lines_missing_text(client):
+    """POST /text/match/lines with empty text returns 400."""
+    payload = {"language": "en", "text": "", "lines": ["a line"], "threshold": 70}
+    response = client.post("/text/match/lines", json=payload)
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Missing text"
+
+
+def test_text_match_lines_missing_lines(client):
+    """POST /text/match/lines with empty lines returns 400."""
+    payload = {"language": "en", "text": "query", "lines": [], "threshold": 70}
+    response = client.post("/text/match/lines", json=payload)
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Missing lines"
+
+
+def test_text_match_lines_invalid_threshold_too_high(client):
+    """POST /text/match/lines with threshold > 100 returns 400."""
+    payload = {"language": "en", "text": "query", "lines": ["line"], "threshold": 101}
+    response = client.post("/text/match/lines", json=payload)
+    assert response.status_code == 400
+    assert "Threshold" in response.json()["detail"]
+
+
+def test_text_match_lines_invalid_threshold_negative(client):
+    """POST /text/match/lines with negative threshold returns 400."""
+    payload = {"language": "en", "text": "query", "lines": ["line"], "threshold": -1}
+    response = client.post("/text/match/lines", json=payload)
+    assert response.status_code == 400
+    assert "Threshold" in response.json()["detail"]


### PR DESCRIPTION
Refs: OPS-11981

This bumps python to 3.13 which is still supported until later this year, bumps the dependencies a bit more and add API tests against the built image.