### PR TITLE
feat: Do configurable logging, for use with ECS.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,6 @@ IMAGE_TAG=local
 # The main build recipe.
 build:  clean
 	$(DOCKER) build \
-				--build-arg BRANCH_ENVIRONMENT=$(NODE_ENV) \
 				--build-arg VCS_REF=`git rev-parse --short HEAD` \
 				--build-arg VCS_URL=`git config --get remote.origin.url | sed 's#git@github.com:#https://github.com/#'` \
 				--build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,7 @@ ENV S6VERSION=2.2.0.3
 COPY . /srv/www
 
 # Fetch s6 init files, needed later.
-RUN apt-get clean && apt-get update && apt-get -y install ca-certificates curl && \
+RUN apt-get clean && apt-get update && apt-get -y install bash ca-certificates curl && \
     S6ARCH=$(uname -m | sed 's/x86_64/amd64/') && \
     echo "Installing s6 version: $S6VERSION for $S6ARCH" && \
     curl -o /tmp/s6-overlay.tar.gz -jkSL https://github.com/just-containers/s6-overlay/releases/download/v${S6VERSION}/s6-overlay-${S6ARCH}.tar.gz

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,7 @@ ENV S6VERSION=2.2.0.3
 COPY . /srv/www
 
 # Fetch s6 init files, needed later.
-RUN apt-get clean && apt-get update && apt-get -y install bash ca-certificates curl && \
+RUN apt-get clean && apt-get update && apt-get -y install ca-certificates curl && \
     S6ARCH=$(uname -m | sed 's/x86_64/amd64/') && \
     echo "Installing s6 version: $S6VERSION for $S6ARCH" && \
     curl -o /tmp/s6-overlay.tar.gz -jkSL https://github.com/just-containers/s6-overlay/releases/download/v${S6VERSION}/s6-overlay-${S6ARCH}.tar.gz
@@ -32,7 +32,8 @@ ENV GIT_BLAME=$GITHUB_ACTOR \
     GIT_REPO=$GITHUB_REPOSITORY \
     GIT_SHA=$GITHUB_SHA \
     GIT_REF=$GITHUB_REF \
-    GIT_MESSAGE=$GITHUB_MESSAGE
+    GIT_MESSAGE=$GITHUB_MESSAGE \
+    HF_TOKEN=$HF_TOKEN
 
 LABEL info.humanitarianresponse.build.date=$BUILD_DATE \
       info.humanitarianresponse.build.vcs-url=$VCS_URL \
@@ -46,14 +47,18 @@ COPY --from=builder /tmp/s6-overlay.tar.gz /tmp/
 COPY --from=builder /srv/www/docker/etc/services/run_uvicorn /tmp/
 
 # Set environment variables to use the virtual environment.
-ENV PATH=/opt/venv/bin:$PATH
+ENV PATH=/opt/venv/bin:$PATH \
+    HF_TOKEN=$HF_TOKEN
 
 RUN \
     apt-get clean && apt-get update && apt-get -y install curl netcat-openbsd procps && \
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
-    # Ensure we install to /usr because /bin and /usr/bin are now both /usr/bin.
-    tar xzf /tmp/s6-overlay.tar.gz -C /usr && \
+    tar vxzf /tmp/s6-overlay.tar.gz -C / && \
     rm -f /tmp/s6-overlay.tar.gz && \
+    # Ensure we move S6 to /usr because /bin and /usr/bin are now both /usr/bin.
+    mv -f /bin/* /usr/bin/ && \
+    rm -rf /bin && \
+    ln -s /usr/bin /bin && \
     # Add some users.
     addgroup --system --gid 4000 appuser && \
     adduser --system --uid 4000 --gid 4000 --shell /sbin/nologin --comment 'Docker App User' --home /home/appuser --no-create-home appuser && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,8 +32,7 @@ ENV GIT_BLAME=$GITHUB_ACTOR \
     GIT_REPO=$GITHUB_REPOSITORY \
     GIT_SHA=$GITHUB_SHA \
     GIT_REF=$GITHUB_REF \
-    GIT_MESSAGE=$GITHUB_MESSAGE \
-    HF_TOKEN=$HF_TOKEN
+    GIT_MESSAGE=$GITHUB_MESSAGE
 
 LABEL info.humanitarianresponse.build.date=$BUILD_DATE \
       info.humanitarianresponse.build.vcs-url=$VCS_URL \
@@ -47,13 +46,12 @@ COPY --from=builder /tmp/s6-overlay.tar.gz /tmp/
 COPY --from=builder /srv/www/docker/etc/services/run_uvicorn /tmp/
 
 # Set environment variables to use the virtual environment.
-ENV PATH=/opt/venv/bin:$PATH \
-    HF_TOKEN=$HF_TOKEN
+ENV PATH=/opt/venv/bin:$PATH
 
 RUN \
     apt-get clean && apt-get update && apt-get -y install curl netcat-openbsd procps && \
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
-    tar vxzf /tmp/s6-overlay.tar.gz -C / && \
+    tar xzf /tmp/s6-overlay.tar.gz -C / && \
     rm -f /tmp/s6-overlay.tar.gz && \
     # Ensure we move S6 to /usr because /bin and /usr/bin are now both /usr/bin.
     mv -f /bin/* /usr/bin/ && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -49,9 +49,10 @@ COPY --from=builder /srv/www/docker/etc/services/run_uvicorn /tmp/
 ENV PATH=/opt/venv/bin:$PATH
 
 RUN \
-    apt-get clean && apt-get update && apt-get -y install netcat-openbsd procps && \
+    apt-get clean && apt-get update && apt-get -y install curl netcat-openbsd procps && \
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
-    tar xzf /tmp/s6-overlay.tar.gz -C / && \
+    # Ensure we install to /usr because /bin and /usr/bin are now both /usr/bin.
+    tar xzf /tmp/s6-overlay.tar.gz -C /usr && \
     rm -f /tmp/s6-overlay.tar.gz && \
     # Add some users.
     addgroup --system --gid 4000 appuser && \

--- a/docker/etc/services/run_uvicorn
+++ b/docker/etc/services/run_uvicorn
@@ -8,5 +8,5 @@ cd /srv/www/html
 exec s6-setuidgid appuser uvicorn app:app \
   --host ${SERVER_HOST:-0.0.0.0} \
   --port ${SERVER_PORT:-8000} \
-  --log-config=log_config.yaml \
+  --log-config=ecs_log_config.yaml \
   --reload

--- a/docker/etc/services/run_uvicorn
+++ b/docker/etc/services/run_uvicorn
@@ -8,5 +8,5 @@ cd /srv/www/html
 exec s6-setuidgid appuser uvicorn app:app \
   --host ${SERVER_HOST:-0.0.0.0} \
   --port ${SERVER_PORT:-8000} \
-  --log-config=ecs_log_config.yaml \
+  --log-config=${LOG_CONFIG:-log_config.yaml} \
   --reload

--- a/html/ecs_log_config.yaml
+++ b/html/ecs_log_config.yaml
@@ -1,0 +1,33 @@
+version: 1
+disable_existing_loggers: False
+formatters:
+  default:
+    "()": uvicorn.logging.DefaultFormatter
+    format: '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+    use_colors: null
+
+  access:
+    "()": uvicorn.logging.AccessFormatter
+    format: "[%(asctime)s %(process)d:%(threadName)s] %(name)s - %(levelname)s - %(message)s | %(filename)s:%(lineno)d"
+
+handlers:
+  default:
+    formatter: default
+    class: logging.StreamHandler
+    stream: ext://sys.stderr
+
+  access:
+    formatter: access
+    class: logging.StreamHandler
+    stream: ext://sys.stdout
+
+loggers:
+  uvicorn.error:
+    level: INFO
+    handlers: [default]
+    propagate: false
+
+  uvicorn.access:
+    level: INFO
+    handlers: [access]
+    propagate: false


### PR DESCRIPTION
A few tweaks to make running (and testing / debugging) on ECS a bit easier.

* Add bash for shell exec.
* Add curl for health check.
* Log to stdout/stderr.
* /bin is dead, long live /bin!

Also note that ECS wants 2GB of memory configure for the task, of we very `SIGKILL` stop working at startup.

Refs: OPS-12232